### PR TITLE
Rectify SQLite origin schema version to 125

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This is a fork of [oliviermaridat/kanboard-sqlite2mysql](https://github.com/oliv
 
 For usage, please refer to the [initial README](https://github.com/oliviermaridat/kanboard-sqlite2mysql/blob/master/README.md).
 
-The script was used to migrate SQLite schema version 120 to PostgreSQL 13 schema version 115.
+The script was used to migrate SQLite schema version 125 to PostgreSQL 13 schema version 115.


### PR DESCRIPTION
This migration was made from a SQLite schema, version 125.